### PR TITLE
Make any get/post/delete/put API requests possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ Here is the usage (check `trl -h` too):
     trl c n <list_shortcut>
         pops your $EDITOR to create a new card in the list specified by list_shortcut
 
-    trl g <api_path>
+    trl api <method_or_path> [<path>]
         make a direct api call adding auth params automatically (for debugging/hacking purpose)
+        method can be get/post/put/delete (default: get)
         Cf. [REST API reference](https://developer.atlassian.com/cloud/trello/rest)
 
 ## Shortcuts

--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ usage:
     trl bm
     trl c <card_shortcut> [o | m <list_shortcut> | e | n <list_shortcut> | co [<comment>]]
     trl c n <list_shortcut>
-    trl g <api_path>
+    trl api <method_or_path> [<path>]
     trl -h
 
     -h --help  this help message
@@ -47,8 +47,9 @@ commands:
     c n <list_shortcut>
         create a new card in the list specified by list_shortcut
 
-    g <api_path>
+    api <method_or_path> [<path>]
         make a direct api call adding auth params automatically (for debugging/hacking purpose)
+        method can be get/post/put/delete (default: get)
         Cf. https://developer.atlassian.com/cloud/trello/rest
 
 env:
@@ -151,6 +152,12 @@ if __name__ == '__main__':
         list_shortcuts = args['<list_shortcuts>']
         usecases.print_lists(list_shortcuts)
 
-    elif args['g']:
-        api_path = args['<api_path>']
-        print(json.dumps(tclient.get(api_path), indent=2))
+    elif args['api']:
+        api_path = args.get('<path>')
+        if api_path is None:
+            api_path = args["<method_or_path>"]
+            method = "get"
+        else:
+            method = args["<method_or_path>"]
+        response = getattr(tclient, method)(api_path)
+        print(json.dumps(response, indent=2))

--- a/trullo/tclient.py
+++ b/trullo/tclient.py
@@ -40,6 +40,10 @@ class TClient:
             )
         )
 
+    def delete(self, path: str) -> Dict:
+        return self.handle_res(
+            requests.delete(self.base_url + path, self.build_auth_params()))
+
     def put(self, path: str) -> Dict:
         return self.handle_res(
             requests.put(self.base_url + path, self.build_auth_params()))


### PR DESCRIPTION
- e.g. `api /members/1233345/notifications` or `api delete /cards/aBcD1234`
- rename command from `g` (for get?) to `api`
- optparse logic is a bit tricky because putting an optional arg before
  a mandatory one (like `[<method>] <path>`) does not work
